### PR TITLE
Update chap6_challenge9.py

### DIFF
--- a/part_I/string_manipulation/challenges/chap6_challenge9.py
+++ b/part_I/string_manipulation/challenges/chap6_challenge9.py
@@ -1,5 +1,5 @@
-concat = "three" + "three" + "three"
-mult = "three" * 3
+concat = "three" + " three" + " three"
+mult = "three " * 3
 
 print(concat)
-print(mult)
+print(mult.strip())


### PR DESCRIPTION
The original version will not leave a space between each word. The strip() is required to remove the extra space at the end when the string is multiplied.